### PR TITLE
Feat : fetch 커스텀 초기 적용

### DIFF
--- a/db.json
+++ b/db.json
@@ -1,0 +1,19 @@
+{
+  "posts": [
+    {
+      "id": 1,
+      "title": "json-server",
+      "author": "typicode"
+    }
+  ],
+  "comments": [
+    {
+      "id": 1,
+      "body": "some comment",
+      "postId": 1
+    }
+  ],
+  "profile": {
+    "name": "typicode"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "react-dom": "^18",
     "react-query": "^3.39.3",
     "recoil": "^0.7.7",
+    "return-fetch": "^0.4.5",
     "yarn": "^1.22.21"
   },
   "devDependencies": {

--- a/src/app/apis/index.ts
+++ b/src/app/apis/index.ts
@@ -1,0 +1,20 @@
+import returnFetch from "return-fetch";
+
+export const fetchExtended = returnFetch({
+  baseUrl: "http://localhost:9999",
+  headers: { Accept: "application/json" },
+  interceptors: {
+    request: async (args) => {
+      console.log("요청 전 interceptor");
+      // 요청 전 accessToken 추가해줄 부분
+      return args;
+    },
+
+    response: async (response, requestArgs) => {
+      console.log("응답 후 interceptor");
+      // 요청 받은 후 작업할 부분
+      // 일단 임시로 return을 json 형식으로 바꾸게 해놨는데 응답폼에 따라 바뀔 수 있으므로 수정 예정
+      return response.json();
+    },
+  },
+});

--- a/src/app/sample/page.tsx
+++ b/src/app/sample/page.tsx
@@ -1,0 +1,9 @@
+import { fetchExtended } from "../apis";
+
+const page = async () => {
+  const response = await fetchExtended("/profile");
+  console.log(response);
+  return <div></div>;
+};
+
+export default page;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2128,6 +2128,11 @@ resolve@^2.0.0-next.4:
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 
+return-fetch@^0.4.5:
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/return-fetch/-/return-fetch-0.4.5.tgz#f243c34383407687d3693dc5c9582b8fbb0d0618"
+  integrity sha512-B4dEbp7cjVuXE0EshS4skHfCdGKYA2U1XDGRCa8EhE6P+R+tAmMtfVskeOI4CAyryD3HNz1esvFGKxOwq4VOhw==
+
 reusify@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"


### PR DESCRIPTION
#6

## 📝 작업 내용
![image](https://github.com/Supingmall/supingmall-fe/assets/112530541/c890728c-e7dc-4c7e-8b13-5838fa7bf943)

- 처음에는 직접 구현해볼까 하다가 시간이 너무 오래 걸릴 것 같아서 원하는 기능만을 구현해놓은 라이브러리를 사용했습니다.

## :sparkles: 리뷰어가 집중해야할 부분

- app/sample/page.tsx에 사용 예시를 적어두었습니다. 
- 추후 모듈화 하면 한 번 더 설명 드리겠습니다.

## ‼️ 주의 사항

- return-fetch 라이브러리 설치 ( yarn install )
- 사용해보시려면 json-server도 실행 시켜야 합니다.
- `npx json-server --port 9999 --watch  db.json`

## 🔗 참고자료

https://blog.deercorp.com/next-js-app-router-and-fetch-library/
